### PR TITLE
Switch data storage to use UUID keys

### DIFF
--- a/bukkit/src/main/kotlin/top/alazeprt/aqqbot/adapter/BukkitAdapter.kt
+++ b/bukkit/src/main/kotlin/top/alazeprt/aqqbot/adapter/BukkitAdapter.kt
@@ -11,6 +11,10 @@ object BukkitAdapter : AQQBotAdapter {
         return BukkitOfflinePlayer(Bukkit.getOfflinePlayer(name))
     }
 
+    override fun getOfflinePlayer(uuid: java.util.UUID): AOfflinePlayer {
+        return BukkitOfflinePlayer(Bukkit.getOfflinePlayer(uuid))
+    }
+
     override fun getOnlinePlayer(name: String): APlayer? {
         return BukkitPlayer(Bukkit.getPlayer(name)?: return null)
     }

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/adapter/AQQBotAdapter.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/adapter/AQQBotAdapter.kt
@@ -7,6 +7,8 @@ import top.alazeprt.aqqbot.profile.APlayer
 interface AQQBotAdapter {
     fun getOfflinePlayer(name: String): AOfflinePlayer
 
+    fun getOfflinePlayer(uuid: java.util.UUID): AOfflinePlayer
+
     fun getOnlinePlayer(name: String): APlayer?
 
     fun getPlayerList(): List<APlayer>

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/data/DatabaseDataProvider.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/data/DatabaseDataProvider.kt
@@ -16,117 +16,68 @@ abstract class DatabaseDataProvider(val plugin: AQQBot): DataProvider {
 
     override fun hasPlayer(player: AOfflinePlayer): Boolean {
         return table.select(dataSource) {
-            rows("name")
-        }.map {
-            if (getString("name").split(", ").toMutableList().isEmpty())
-                getString("name") == player.getName()
-            else getString("name").split(", ").toMutableList().contains(player.getName())
-        }.any { it }
+            rows("qq")
+            where("uuid" eq player.getUUID().toString())
+            limit(1)
+        }.firstOrNull { getLong("qq") } != null
     }
 
     override fun hasQQ(qq: Long): Boolean {
         return table.select(dataSource) {
-            rows("name")
-            where("userId" eq qq)
+            rows("uuid")
+            where("qq" eq qq)
             limit(1)
-        }.firstOrNull { getString("name") } != null
+        }.firstOrNull { getString("uuid") } != null
     }
 
     override fun addPlayer(qq: Long, player: AOfflinePlayer) {
-        var originList: MutableList<String> = mutableListOf();
-        if (hasQQ(qq)) {
-            table.select(dataSource) {
-                where("userId" eq qq)
-                rows("name")
-            }.map {
-                originList = if (getString("name").split(", ").toMutableList().isEmpty())
-                    mutableListOf(getString("name")) else getString("name").split(", ").toMutableList()
-            }
-        }
-        originList.add(player.getName())
-        if (originList.size == 1) {
-            table.insert(dataSource, "userId", "name") {
-                value(qq, originList.joinToString(", "))
+        if (hasPlayer(player)) {
+            table.update(dataSource) {
+                where("uuid" eq player.getUUID().toString())
+                set("qq", qq)
             }
         } else {
-            table.update(dataSource) {
-                where("userId" eq qq)
-                set("name", originList.joinToString(", "))
+            table.insert(dataSource, "uuid", "qq") {
+                value(player.getUUID().toString(), qq)
             }
         }
     }
 
     override fun removePlayer(qq: Long) {
         table.delete(dataSource) {
-            where("userId" eq qq)
+            where("qq" eq qq)
         }
     }
 
     override fun removePlayer(player: AOfflinePlayer) {
-        val userId = ""
-        val list = mutableListOf<String>()
-        table.select(dataSource) {
-            rows("userId", "name")
-        }.map {
-            if (if (getString("name").split(", ").toMutableList().isEmpty())
-                    getString("name") == player.getName()
-                else getString("name").split(", ").toMutableList().contains(player.getName())) {
-                val newList = if (getString("name").split(", ").toMutableList().isEmpty())
-                    mutableListOf(getString("name")) else getString("name").split(", ").toMutableList()
-                newList.remove(player.getName())
-                list.addAll(newList)
-            }
-        }
-        table.update(dataSource) {
-            set("name", list.joinToString(", "))
-            where("userId" eq userId)
+        table.delete(dataSource) {
+            where("uuid" eq player.getUUID().toString())
         }
     }
 
     override fun removePlayer(qq: Long, player: AOfflinePlayer) {
-        val list = mutableListOf<String>()
-        table.select(dataSource) {
-            rows("name")
-            where("userId" eq qq)
-        }.map {
-            if (if (getString("name").split(", ").toMutableList().isEmpty())
-                    getString("name") == player.getName()
-                else getString("name").split(", ").toMutableList().contains(player.getName())) {
-                val newList = if (getString("name").split(", ").toMutableList().isEmpty())
-                    mutableListOf(getString("name")) else getString("name").split(", ").toMutableList()
-                newList.remove(player.getName())
-                list.addAll(newList)
-            }
-        }
-        table.update(dataSource) {
-            set("name", list.joinToString(", "))
-            where("userId" eq qq)
+        if (getQQByPlayer(player) == qq) {
+            removePlayer(player)
         }
     }
 
     override fun getQQByPlayer(player: AOfflinePlayer): Long? {
-        var userId: Long? = null
-        table.select(dataSource) {
-            rows("userId", "name")
-        }.map {
-            if (if (getString("name").split(", ").toMutableList().isEmpty())
-                    getString("name") == player.getName() else getString("name").split(", ").toMutableList().contains(player.getName())) {
-
-                userId = getLong("userId")
-                return@map
-            }
-        }
-        return userId
+        return table.select(dataSource) {
+            rows("qq")
+            where("uuid" eq player.getUUID().toString())
+            limit(1)
+        }.firstOrNull { getLong("qq") }
     }
 
     override fun getPlayerByQQ(qq: Long): List<AOfflinePlayer> {
-        val list = table.select(dataSource) {
-            rows("name")
-            where("userId" eq qq)
-            limit(1)
-        }.firstOrNull { if (getString("name").split(", ").toMutableList().isEmpty())
-            mutableListOf(getString("name")) else getString("name").split(", ").toMutableList() }?: mutableListOf()
-        return list.map { plugin.adapter!!.getOfflinePlayer(it) }
+        val list = mutableListOf<AOfflinePlayer>()
+        table.select(dataSource) {
+            rows("uuid")
+            where("qq" eq qq)
+        }.map {
+            list.add(plugin.adapter!!.getOfflinePlayer(java.util.UUID.fromString(getString("uuid"))))
+        }
+        return list
     }
 
 }

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/data/FileDataProvider.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/data/FileDataProvider.kt
@@ -10,12 +10,12 @@ class FileDataProvider(val plugin: AQQBot) : DataProvider {
 
     private val file = File(plugin.getDataFolder(), "data.yml")
     private lateinit var dataConfig: FileConfiguration
-    val dataMap: MutableMap<String, MutableList<String>> = mutableMapOf()
+    val dataMap: MutableMap<String, String> = mutableMapOf()
 
     override fun loadData(type: DataStorageType) {
         dataConfig = YamlConfiguration.loadConfiguration(file)
         dataConfig.getKeys(false).forEach {
-            dataMap[it] = dataConfig.getStringList(it).toMutableList()
+            dataMap[it] = dataConfig.getString(it) ?: ""
         }
     }
 
@@ -31,61 +31,37 @@ class FileDataProvider(val plugin: AQQBot) : DataProvider {
     }
 
     override fun hasPlayer(player: AOfflinePlayer): Boolean {
-        dataMap.values.forEach {
-            if (it.contains(player.getName())) {
-                return true
-            }
-        }
-        return false
+        return dataMap.containsKey(player.getUUID().toString())
     }
 
     override fun hasQQ(qq: Long): Boolean {
-        return dataMap.containsKey(qq.toString())
+        return dataMap.values.any { it == qq.toString() }
     }
 
     override fun addPlayer(qq: Long, player: AOfflinePlayer) {
-        val list = getPlayerByQQ(qq).map { it.getName() }.toMutableList()
-        list.add(player.getName())
-        dataMap[qq.toString()] = list
+        dataMap[player.getUUID().toString()] = qq.toString()
     }
 
     override fun removePlayer(player: AOfflinePlayer) {
-        dataMap.values.forEach { value ->
-            if (value.contains(player.getName())) {
-                value.remove(player.getName())
-                return
-            }
-        }
+        dataMap.remove(player.getUUID().toString())
     }
 
     override fun removePlayer(qq: Long) {
-        if (hasQQ(qq)) dataMap.remove(qq.toString())
+        dataMap.entries.removeIf { it.value == qq.toString() }
     }
 
     override fun removePlayer(qq: Long, player: AOfflinePlayer) {
-        if (hasQQ(qq)) {
-            dataMap.get(qq.toString())!!.forEach {
-                if (it == player.getName()) {
-                    dataMap[qq.toString()]!!.remove(it)
-                    return
-                }
-            }
+        if (dataMap[player.getUUID().toString()] == qq.toString()) {
+            dataMap.remove(player.getUUID().toString())
         }
     }
 
     override fun getQQByPlayer(player: AOfflinePlayer): Long? {
-        dataMap.forEach {
-            it.value.forEach { value ->
-                if (value == player.getName()) {
-                    return it.key.toLong()
-                }
-            }
-        }
-        return null
+        return dataMap[player.getUUID().toString()]?.toLong()
     }
 
     override fun getPlayerByQQ(qq: Long): List<AOfflinePlayer> {
-        if (!hasQQ(qq)) return emptyList()
-        return dataMap[qq.toString()]!!.map { plugin.adapter!!.getOfflinePlayer(it) }
+        return dataMap.filterValues { it == qq.toString() }
+            .map { plugin.adapter!!.getOfflinePlayer(java.util.UUID.fromString(it.key)) }
     }
 }

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/data/MySQLProvider.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/data/MySQLProvider.kt
@@ -28,13 +28,13 @@ class MySQLProvider(plugin: AQQBot) : DatabaseDataProvider(plugin) {
         val dataSource by lazy { host.createDataSource() }
 
         table = Table("account_data", host) {
-            add("userId") {
-                type(ColumnTypeSQL.BIGINT) {
+            add("uuid") {
+                type(ColumnTypeSQL.VARCHAR, 36) {
                     options(ColumnOptionSQL.PRIMARY_KEY)
                 }
             }
-            add("name") {
-                type(ColumnTypeSQL.VARCHAR, 128) {
+            add("qq") {
+                type(ColumnTypeSQL.BIGINT) {
                     options(ColumnOptionSQL.NOTNULL)
                 }
             }

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/data/SQLiteProvider.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/data/SQLiteProvider.kt
@@ -22,13 +22,13 @@ class SQLiteProvider(plugin: AQQBot) : DatabaseDataProvider(plugin) {
         Database.settingsFile = DatabaseSource(dataSourceConfig)
         val dataSource by lazy { host.createDataSource() }
         table = Table("account_data", host) {
-            add("userId") {
-                type(ColumnTypeSQLite.INTEGER) {
+            add("uuid") {
+                type(ColumnTypeSQLite.TEXT) {
                     options(ColumnOptionSQLite.PRIMARY_KEY)
                 }
             }
-            add("name") {
-                type(ColumnTypeSQLite.TEXT) {
+            add("qq") {
+                type(ColumnTypeSQLite.INTEGER) {
                     options(ColumnOptionSQLite.NOTNULL)
                 }
             }

--- a/folia/src/main/kotlin/top/alazeprt/aqqbot/adapter/BukkitAdapter.kt
+++ b/folia/src/main/kotlin/top/alazeprt/aqqbot/adapter/BukkitAdapter.kt
@@ -11,6 +11,10 @@ object BukkitAdapter : AQQBotAdapter {
         return BukkitOfflinePlayer(Bukkit.getOfflinePlayer(name))
     }
 
+    override fun getOfflinePlayer(uuid: java.util.UUID): AOfflinePlayer {
+        return BukkitOfflinePlayer(Bukkit.getOfflinePlayer(uuid))
+    }
+
     override fun getOnlinePlayer(name: String): APlayer? {
         return BukkitPlayer(Bukkit.getPlayer(name)?: return null)
     }

--- a/velocity/src/main/kotlin/top/alazeprt/aqqbot/adapter/VelocityAdapter.kt
+++ b/velocity/src/main/kotlin/top/alazeprt/aqqbot/adapter/VelocityAdapter.kt
@@ -12,6 +12,10 @@ class VelocityAdapter(val plugin: AQQBotVelocity) : AQQBotAdapter {
         return VelocityOfflinePlayer(GameProfile.forOfflinePlayer(name))
     }
 
+    override fun getOfflinePlayer(uuid: java.util.UUID): AOfflinePlayer {
+        return VelocityOfflinePlayer(GameProfile(uuid, "unknown", listOf()))
+    }
+
     override fun getOnlinePlayer(name: String): APlayer? {
         return plugin.server.getPlayer(name).getOrNull()?.let { VelocityPlayer(it) }
     }


### PR DESCRIPTION
## Summary
- map player UUIDs to QQ numbers
- update database schema and providers
- expose adapter API for loading offline players via UUID

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684b57f76c64832c94a2b1518809d9f2