### PR TITLE
Add optional limited login for unbound players

### DIFF
--- a/bukkit/src/main/kotlin/top/alazeprt/aqqbot/AQQBotBukkit.kt
+++ b/bukkit/src/main/kotlin/top/alazeprt/aqqbot/AQQBotBukkit.kt
@@ -36,6 +36,8 @@ class AQQBotBukkit : JavaPlugin(), AQQBot {
     override val bindCooldownMap: MutableMap<String, Long> = mutableMapOf()
     override val unbindCooldownMap: MutableMap<String, Long> = mutableMapOf()
 
+    override val unboundPlayers: MutableSet<String> = mutableSetOf()
+
     override lateinit var dataProvider: DataProvider
 
     override lateinit var enableGroups: MutableList<String>

--- a/bukkit/src/main/kotlin/top/alazeprt/aqqbot/adapter/BukkitPlayer.kt
+++ b/bukkit/src/main/kotlin/top/alazeprt/aqqbot/adapter/BukkitPlayer.kt
@@ -30,4 +30,8 @@ class BukkitPlayer(val player: Player) : APlayer {
     override fun hasPermission(permission: String): Boolean {
         return player.hasPermission(permission)
     }
+
+    override fun sendTitle(title: String, subTitle: String) {
+        player.sendTitle(title, subTitle, 10, 70, 20)
+    }
 }

--- a/bukkit/src/main/kotlin/top/alazeprt/aqqbot/event/BukkitEventHandler.kt
+++ b/bukkit/src/main/kotlin/top/alazeprt/aqqbot/event/BukkitEventHandler.kt
@@ -6,6 +6,7 @@ import org.bukkit.event.player.AsyncPlayerChatEvent
 import org.bukkit.event.player.PlayerJoinEvent
 import org.bukkit.event.player.PlayerLoginEvent
 import org.bukkit.event.player.PlayerQuitEvent
+import org.bukkit.event.player.PlayerMoveEvent
 import top.alazeprt.aqqbot.AQQBotBukkit
 import top.alazeprt.aqqbot.adapter.BukkitPlayer
 
@@ -23,5 +24,13 @@ class BukkitEventHandler(val plugin: AQQBotBukkit) : Listener {
     @EventHandler
     fun onQuit(event: PlayerQuitEvent) {
         AQuitEvent(plugin, BukkitPlayer(event.player)).handle()
+    }
+
+    @EventHandler
+    fun onMove(event: PlayerMoveEvent) {
+        if (plugin.generalConfig.getBoolean("whitelist.login_server_is_allowed_but_limit") &&
+            plugin.unboundPlayers.contains(event.player.name)) {
+            event.isCancelled = true
+        }
     }
 }

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/AQQBot.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/AQQBot.kt
@@ -30,6 +30,8 @@ interface AQQBot: ConfigProvider, CommandProvider, DataProvider, HookProvider, T
     val bindCooldownMap: MutableMap<String, Long>  // <name, time>
     val unbindCooldownMap: MutableMap<String, Long>
 
+    val unboundPlayers: MutableSet<String>
+
     var dataProvider: DataProvider
 
     var toGroupFormatter: AFormatter

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/config/ConfigProvider.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/config/ConfigProvider.kt
@@ -43,6 +43,12 @@ interface ConfigProvider {
         if (generalConfig.getInt("chat.max_forward_length") <= 0) {
             generalConfig.set("chat.max_forward_length", 200)
         }
+        if (!generalConfig.contains("whitelist.login_server_is_allowed_but_limit")) {
+            generalConfig.set("whitelist.login_server_is_allowed_but_limit", false)
+        }
+        if (!generalConfig.contains("whitelist.login_server_is_allowed_but_remind")) {
+            generalConfig.set("whitelist.login_server_is_allowed_but_remind", false)
+        }
         if (generalConfig.getInt("version") != 17) {
             generalConfig.set("version", 17)
             generalConfig.set("whitelist.cooldown.bind", 60)

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/event/AJoinEvent.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/event/AJoinEvent.kt
@@ -5,6 +5,7 @@ import top.alazeprt.aqqbot.AQQBot
 import top.alazeprt.aqqbot.event.AEventUtil.playerStatusHandler
 import top.alazeprt.aqqbot.event.AEventUtil.whitelistHandler
 import top.alazeprt.aqqbot.profile.APlayer
+import java.util.UUID
 
 class AJoinEvent(val plugin: AQQBot, private val player: APlayer) : AEvent {
     override fun handle() {
@@ -25,6 +26,27 @@ class AJoinEvent(val plugin: AQQBot, private val player: APlayer) : AEvent {
         }
 
         if (!handle1 || !handle2) {
+            if (!plugin.generalConfig.getBoolean("whitelist.need_bind_to_login") &&
+                plugin.generalConfig.getBoolean("whitelist.login_server_is_allowed_but_limit") &&
+                !plugin.hasPlayer(plugin.adapter!!.getOfflinePlayer(player.getName()))) {
+                plugin.unboundPlayers.add(player.getName())
+            }
+            if (!plugin.generalConfig.getBoolean("whitelist.need_bind_to_login") &&
+                plugin.generalConfig.getBoolean("whitelist.login_server_is_allowed_but_remind") &&
+                !plugin.hasPlayer(plugin.adapter!!.getOfflinePlayer(player.getName()))) {
+                val verifyCode = plugin.verifyCodeMap[player.getName()]?.first ?: UUID.randomUUID().toString().substring(0, 6)
+                if (!plugin.verifyCodeMap.containsKey(player.getName())) {
+                    plugin.verifyCodeMap[player.getName()] = Pair(verifyCode, System.currentTimeMillis())
+                }
+                plugin.submitAsync {
+                    while (plugin.unboundPlayers.contains(player.getName())) {
+                        val p = plugin.adapter!!.getOnlinePlayer(player.getName()) ?: break
+                        p.sendMessage("§c您未绑定账号，请加群发送绑定码\n§e绑定码: $verifyCode")
+                        p.sendTitle("§c您未绑定账号", "§e绑定码: $verifyCode")
+                        Thread.sleep(100L * 50L)
+                    }
+                }
+            }
             playerStatusHandler(plugin, player, true)
             if (plugin.configNeedUpdate() && player.hasPermission("aqqbot.admin")) {
                 plugin.submitLater(10) {

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/event/AQuitEvent.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/event/AQuitEvent.kt
@@ -7,5 +7,6 @@ import top.alazeprt.aqqbot.profile.APlayer
 class AQuitEvent(val plugin: AQQBot, private val player: APlayer): AEvent {
     override fun handle() {
         playerStatusHandler(plugin, player, false)
+        plugin.unboundPlayers.remove(player.getName())
     }
 }

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/handler/WhitelistHandler.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/handler/WhitelistHandler.kt
@@ -45,6 +45,7 @@ class WhitelistHandler(val plugin: AQQBot) {
             return false
         }
         plugin.addPlayer(userId.toLong(), plugin.adapter!!.getOfflinePlayer(playerName))
+        plugin.unboundPlayers.remove(playerName)
         BotProvider.getBot()?.action(SendGroupMessage(groupId, plugin.getMessageManager().get("qq.whitelist.bind_successful"), true))
         plugin.debugModule?.debugLogger?.log("$userId bind $userId to account $playerName")
         if (config.getString("whitelist.verify_method")?.uppercase() == "VERIFY_CODE") {

--- a/common/src/main/kotlin/top/alazeprt/aqqbot/profile/APlayer.kt
+++ b/common/src/main/kotlin/top/alazeprt/aqqbot/profile/APlayer.kt
@@ -2,4 +2,11 @@ package top.alazeprt.aqqbot.profile
 
 interface APlayer: AOfflinePlayer, ASender {
     fun kick(reason: String)
+
+    /**
+     * 向玩家发送标题信息
+     * @param title 主标题
+     * @param subTitle 副标题
+     */
+    fun sendTitle(title: String, subTitle: String)
 }

--- a/common/src/main/resources/config.yml
+++ b/common/src/main/resources/config.yml
@@ -30,6 +30,10 @@ whitelist:
   # 是否必须绑定后才能进入游戏
   # ! 若关闭该功能, 则 VERIFY_CODE 的验证方法不起效
   need_bind_to_login: true
+  # 若允许未绑定进入但限制移动, 设置为 true
+  login_server_is_allowed_but_limit: false
+  # 若允许未绑定进入时循环提醒绑定, 设置为 true
+  login_server_is_allowed_but_remind: false
 
   # 验证方法
   # - GROUP_NAME: 在QQ群中发送 $command $name 来给自己的QQ绑定指定的游戏账户(名称)

--- a/folia/src/main/kotlin/top/alazeprt/aqqbot/AQQBotBukkit.kt
+++ b/folia/src/main/kotlin/top/alazeprt/aqqbot/AQQBotBukkit.kt
@@ -38,6 +38,8 @@ class AQQBotBukkit : JavaPlugin(), AQQBot {
     override val bindCooldownMap: MutableMap<String, Long> = mutableMapOf()
     override val unbindCooldownMap: MutableMap<String, Long> = mutableMapOf()
 
+    override val unboundPlayers: MutableSet<String> = mutableSetOf()
+
     override lateinit var dataProvider: DataProvider
 
     override lateinit var enableGroups: MutableList<String>

--- a/folia/src/main/kotlin/top/alazeprt/aqqbot/adapter/BukkitPlayer.kt
+++ b/folia/src/main/kotlin/top/alazeprt/aqqbot/adapter/BukkitPlayer.kt
@@ -30,4 +30,8 @@ class BukkitPlayer(val player: Player) : APlayer {
     override fun hasPermission(permission: String): Boolean {
         return player.hasPermission(permission)
     }
+
+    override fun sendTitle(title: String, subTitle: String) {
+        player.sendTitle(title, subTitle, 10, 70, 20)
+    }
 }

--- a/folia/src/main/kotlin/top/alazeprt/aqqbot/event/BukkitEventHandler.kt
+++ b/folia/src/main/kotlin/top/alazeprt/aqqbot/event/BukkitEventHandler.kt
@@ -21,4 +21,12 @@ class BukkitEventHandler(val plugin: AQQBotBukkit) : Listener {
     fun onQuit(event: PlayerQuitEvent) {
         AQuitEvent(plugin, BukkitPlayer(event.player)).handle()
     }
+
+    @EventHandler
+    fun onMove(event: PlayerMoveEvent) {
+        if (plugin.generalConfig.getBoolean("whitelist.login_server_is_allowed_but_limit") &&
+            plugin.unboundPlayers.contains(event.player.name)) {
+            event.isCancelled = true
+        }
+    }
 }

--- a/velocity/src/main/kotlin/top/alazeprt/aqqbot/AQQBotVelocity.kt
+++ b/velocity/src/main/kotlin/top/alazeprt/aqqbot/AQQBotVelocity.kt
@@ -53,6 +53,8 @@ class AQQBotVelocity : AQQBot {
     override val bindCooldownMap: MutableMap<String, Long> = mutableMapOf()
     override val unbindCooldownMap: MutableMap<String, Long> = mutableMapOf()
 
+    override val unboundPlayers: MutableSet<String> = mutableSetOf()
+
     override lateinit var toGameFormatter: AFormatter
     override lateinit var toGroupFormatter: AFormatter
 

--- a/velocity/src/main/kotlin/top/alazeprt/aqqbot/adapter/VelocityPlayer.kt
+++ b/velocity/src/main/kotlin/top/alazeprt/aqqbot/adapter/VelocityPlayer.kt
@@ -2,6 +2,7 @@ package top.alazeprt.aqqbot.adapter
 
 import com.velocitypowered.api.proxy.Player
 import net.kyori.adventure.text.Component
+import com.velocitypowered.api.util.title.Title
 import top.alazeprt.aqqbot.profile.APlayer
 import java.util.*
 
@@ -30,4 +31,8 @@ class VelocityPlayer(val player: Player) : APlayer {
         return player.hasPermission(permission)
     }
 
+    override fun sendTitle(title: String, subTitle: String) {
+        val t = Title.title(Component.text(title), Component.text(subTitle))
+        player.showTitle(t)
+    }
 }


### PR DESCRIPTION
## Summary
- allow unbound players to join server with restrictions
- track unbound players in plugin
- block movement for unbound players on Bukkit/Folia
- update whitelist configuration and defaults
- cleanup unbound list on bind and quit
- 循环提醒未绑定玩家绑定账号

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684b6827ef44832ca3c62db5426e057a